### PR TITLE
Register service worker

### DIFF
--- a/rails/app/javascript/packs/application.js
+++ b/rails/app/javascript/packs/application.js
@@ -18,3 +18,7 @@
 console.log('Hello World from Webpacker')
 
 import "controllers"
+
+import { register as registerServiceWorker } from "service_worker"
+
+registerServiceWorker()

--- a/rails/app/javascript/packs/service-worker.js
+++ b/rails/app/javascript/packs/service-worker.js
@@ -1,0 +1,3 @@
+import { worker } from "service_worker"
+
+worker()

--- a/rails/app/javascript/service_worker/index.js
+++ b/rails/app/javascript/service_worker/index.js
@@ -1,0 +1,16 @@
+export function register() {
+  // Check that service workers are supported
+  if ('serviceWorker' in navigator) {
+    // Use the window load event to keep the page load performant
+    window.addEventListener('load', () => {
+      console.log("theoretically registering service worker")
+      navigator.serviceWorker.register('/packs/service-worker.js');
+    });
+  } else {
+    console.log("service workers not supported; cannot use offline.")
+  }
+}
+
+export function worker() {
+  console.log("service worker registered")
+}

--- a/rails/config/webpack/environment.js
+++ b/rails/config/webpack/environment.js
@@ -1,3 +1,14 @@
 const { environment } = require('@rails/webpacker')
 
+// TODO:
+// We need the service worker to have a consistent rather than a hashed filename.
+// It was easiest to configure webpacker to use consistent bundle filenames
+// for all entry points rather than just the service worker.
+// THIS IS NOT GOOD AND SHOULD BE FIXED BEFORE PRODUCTION.
+// reference for what fixing it might look like:
+// https://github.com/webpack/webpack/blob/master/examples/multi-compiler/webpack.config.js
+// but it looks like there might be a lot of translation between webpacker & our
+// overrides involved in that transition. :(
+environment.config.set('output.filename', '[name].js')
+
 module.exports = environment


### PR DESCRIPTION
This commit also removes hashes from all webpack bundle filenames.
Service workers' filename must be stable rather than include a
a cache-busting hash or the browser doesn't treat it as the same
SW. While it's possible to configure different webpack entry points
to have different output filenames, this appeared difficult to do
within webpacker, so we elected to defer that work and maintain
velocity. We'll want to restore filename hashes to application.js
(though NOT to servie-worker.js) prior to production use.

### Type of change

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

When any page is loaded in a service-worker-capable browser, the
JavaScript console should log registration of the service worker.
Note that you may need to manually un-register the service worker
in browser devtools to allow for re-registration in testing.