### PR TITLE
Dive finish workflow

### DIFF
--- a/rails/app/controllers/dives_controller.rb
+++ b/rails/app/controllers/dives_controller.rb
@@ -18,6 +18,11 @@ class DivesController < ApplicationController
     end
   end
 
+  def finish
+    dive.finish
+    redirect_to :dive
+  end
+
   private def dive
     @dive ||= Dive.find(params[:id])
   end

--- a/rails/app/models/dive.rb
+++ b/rails/app/models/dive.rb
@@ -3,5 +3,14 @@ class Dive < ApplicationRecord
 
   validates :i_have_been_responsible,
     acceptance: true,
-    presence: true
+    presence: true,
+    on: :create
+
+  def finish
+    self.update(finished_at: Time.now)
+  end
+
+  def finished?
+    finished_at.present?
+  end
 end

--- a/rails/app/views/dives/show.html.erb
+++ b/rails/app/views/dives/show.html.erb
@@ -1,1 +1,7 @@
 <h1><%=t '.title', dive_id: dive.id %></h1>
+
+<%- if dive.finished? %>
+  <%=t '.finished_at_log_message', finished_at: dive.finished_at.to_formatted_s(:db) %>
+<%- else %>
+  <%= button_to t('.finish_button'), [:finish, dive], method: :post %>
+<%- end %>

--- a/rails/config/locales/en.yml
+++ b/rails/config/locales/en.yml
@@ -38,3 +38,5 @@ en:
       submit: "Start dive"
     show:
       title: "On dive #%{dive_id}"
+      finished_at_log_message: "Finished at %{finished_at}."
+      finish_button: "Finish dive"

--- a/rails/config/routes.rb
+++ b/rails/config/routes.rb
@@ -4,7 +4,9 @@ Rails.application.routes.draw do
   devise_for :users  
   resources :nursery_tables
   resources :zones
-  resources :dives, only: [:new, :create, :show]
+  resources :dives, only: [:new, :create, :show] do
+    post :finish, on: :member
+  end
 
   devise_scope :user do
     get 'sign_in', to: 'devise/sessions#new'

--- a/rails/db/migrate/20190726202326_add_finished_at_to_dives.rb
+++ b/rails/db/migrate/20190726202326_add_finished_at_to_dives.rb
@@ -1,0 +1,5 @@
+class AddFinishedAtToDives < ActiveRecord::Migration[5.2]
+  def change
+    add_column :dives, :finished_at, :timestamp
+  end
+end

--- a/rails/spec/models/dive_spec.rb
+++ b/rails/spec/models/dive_spec.rb
@@ -16,4 +16,30 @@ RSpec.describe Dive do
       expect(subject).not_to be_valid
     end
   end
+
+  describe "finishing the dive" do
+    it "sets the finish time" do
+      subject = FactoryBot.create(:dive)
+
+      subject.finish
+
+      expect(subject.finished_at).to be_present
+    end
+  end
+
+  describe "checking if a dive is finished" do
+    it "is true if finished_at is set" do
+      subject = FactoryBot.build(:dive)
+      subject.finished_at = Time.now
+
+      expect(subject).to be_finished
+    end
+
+    it "is false if finished_at is notset" do
+      subject = FactoryBot.build(:dive)
+      subject.finished_at = nil
+
+      expect(subject).not_to be_finished
+    end
+  end
 end

--- a/rails/spec/requests/dives_spec.rb
+++ b/rails/spec/requests/dives_spec.rb
@@ -57,4 +57,29 @@ RSpec.describe "Dives", type: :request do
       end
     end
   end
+
+  describe "POST finish" do
+    let!(:dive) { FactoryBot.create(:dive) } 
+
+    subject do
+      -> {
+        post "/dives/#{dive.id}/finish"
+      }
+    end
+
+    it "redirects to the dive page" do
+      subject.call
+      expect(response).to be_redirect
+
+      follow_redirect!
+      expect(response).to be_successful
+    end
+
+    it "marks the dive as finished" do
+      subject.call
+      
+      dive.reload
+      expect(dive.finished_at).not_to be_nil
+    end
+  end
 end


### PR DESCRIPTION
### Description
Allow users to finish a dive.

### Type of change
* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?
After making a dive (using /dive/new), click "Finish Dive."
You ought to see the timestamp of when the dive was finished.