### PR TITLE
Allow service worker to pre-cache content selectively

### DIFF
--- a/rails/app/assets/javascripts/serviceworker-companion.js
+++ b/rails/app/assets/javascripts/serviceworker-companion.js
@@ -1,5 +1,5 @@
 if (navigator.serviceWorker) {
-  navigator.serviceWorker.register('/serviceworker.js', { scope: './' })
+  navigator.serviceWorker.register('/serviceworker.js', { scope: '/' })
     .then(function(reg) {
       var registrationEvent = new Event('serviceWorkerRegistered');
       document.dispatchEvent(registrationEvent);

--- a/rails/app/assets/javascripts/serviceworker-companion.js
+++ b/rails/app/assets/javascripts/serviceworker-companion.js
@@ -1,6 +1,8 @@
 if (navigator.serviceWorker) {
   navigator.serviceWorker.register('/serviceworker.js', { scope: './' })
     .then(function(reg) {
+      var registrationEvent = new Event('serviceWorkerRegistered');
+      document.dispatchEvent(registrationEvent);
       console.log('[Companion]', 'Service worker registered!');
     });
 }

--- a/rails/app/assets/javascripts/serviceworker.js.erb
+++ b/rails/app/assets/javascripts/serviceworker.js.erb
@@ -46,6 +46,7 @@ function onFetch(event) {
     fetch(event.request).catch(function() {
       // if it fails, try to return request from the cache
       console.log('stepping in');
+      console.log(event.request);
       return caches.match(event.request).then(function(response) {
         if (response) {
           console.log('the caching request worked!');
@@ -65,6 +66,13 @@ function onFetch(event) {
 
 function onMessage(event) {
   console.log('service worker received:', event.data);
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(function addZonePage(cache) {
+      return cache.addAll([
+        '/zones',
+      ]);
+    })
+  );
 }
 
 self.addEventListener('install', onInstall);

--- a/rails/app/assets/javascripts/serviceworker.js.erb
+++ b/rails/app/assets/javascripts/serviceworker.js.erb
@@ -36,6 +36,7 @@ function onActivate(event) {
       );
     })
   );
+  event.waitUntil(self.clients.claim());
 }
 
 // Borrowed from https://github.com/TalAter/UpUp
@@ -62,6 +63,12 @@ function onFetch(event) {
   );
 }
 
+function onMessage(event) {
+  console.log('service worker received:', event.data);
+}
+
 self.addEventListener('install', onInstall);
 self.addEventListener('activate', onActivate);
 self.addEventListener('fetch', onFetch);
+self.addEventListener('message', onMessage);
+

--- a/rails/app/javascript/packs/application.js
+++ b/rails/app/javascript/packs/application.js
@@ -18,3 +18,14 @@
 console.log('Hello World from Webpacker')
 
 import "controllers"
+
+document.addEventListener('serviceWorkerRegistered', () => {
+  console.log("webpack heard the sw register");
+
+  if (!navigator.serviceWorker.controller) {
+    console.log('error: no sw controller');
+    return;
+  }
+
+  navigator.serviceWorker.controller.postMessage("I worked!!!!");
+})


### PR DESCRIPTION
### Description
The service worker can pre-cache content bundles when prompted
by the UI through a message, not just on installation.

### Type of change

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

Un-register any service worker that's active for the site.
Reload any page BUT the zones index page.
Turn your Rails server off, and then navigate to /zones.
It should work.