### PR TITLE
Allow service worker to cache forms on first pageload

### DIFF
--- a/rails/app/assets/javascripts/serviceworker.js.erb
+++ b/rails/app/assets/javascripts/serviceworker.js.erb
@@ -66,17 +66,19 @@ function onFetch(event) {
 
 function onMessage(event) {
   console.log('service worker received:', event.data);
-  event.waitUntil(
-    caches.open(CACHE_NAME).then(function addZonePage(cache) {
-      return cache.addAll([
-        '/zones',
-      ]);
-    })
-  );
+  if (event.data.type === 'fetchForms') {
+    console.log("caching forms")
+    event.waitUntil(
+      caches.open(CACHE_NAME).then(function cacheLogForms(cache) {
+        return cache.addAll([
+          '/restoration_activity_log_entries/new', 
+        ]);
+      })
+    );
+  }
 }
 
 self.addEventListener('install', onInstall);
 self.addEventListener('activate', onActivate);
 self.addEventListener('fetch', onFetch);
 self.addEventListener('message', onMessage);
-

--- a/rails/app/javascript/packs/application.js
+++ b/rails/app/javascript/packs/application.js
@@ -22,10 +22,14 @@ import "controllers"
 document.addEventListener('serviceWorkerRegistered', () => {
   console.log("webpack heard the sw register");
 
-  if (!navigator.serviceWorker.controller) {
-    console.log('error: no sw controller');
-    return;
+  if (navigator.serviceWorker.controller) {
+    fetchForms()
+  } else {
+    navigator.serviceWorker.addEventListener('controllerchange', fetchForms);
   }
+});
 
-  navigator.serviceWorker.controller.postMessage("I worked!!!!");
-})
+function fetchForms() {
+  console.log('fetching forms');
+  navigator.serviceWorker.controller.postMessage({ type: 'fetchForms' });
+}


### PR DESCRIPTION
### Description
Fixes bug where service worker caching of offlinable forms
would only work on the second pageload after registering the worker.

### Type of change
* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
1. Un-register any existing service worker.
2. Clear the service worker's cache.
3. Load any page.
4. Terminate your Rails process.
5. Load /restoration_activity_log_entries/new. It should work.