### PR TITLE
Add rake task 'test' to run rspec and js tests, and enable command line output for js tests

### DIFF
--- a/rails/Gemfile
+++ b/rails/Gemfile
@@ -49,6 +49,9 @@ group :development, :test do
   gem "byebug", platforms: %i[mri mingw x64_mingw]
   gem "dotenv-rails", "~> 2.7"
   gem "factory_bot_rails"
+  gem "selenium-webdriver"
+  gem "teaspoon"
+  gem "teaspoon-mocha"
 end
 
 group :development do

--- a/rails/Rakefile
+++ b/rails/Rakefile
@@ -4,3 +4,16 @@
 require_relative "config/application"
 
 Rails.application.load_tasks
+
+begin
+  require 'rspec/core/rake_task'
+
+  RSpec::Core::RakeTask.new(:rspec)
+rescue LoadError
+  # no rspec available
+end
+
+task :test do
+  Rake::Task["rspec"].invoke
+  Rake::Task["teaspoon"].invoke
+end

--- a/rails/spec/javascript/spec_helper.js
+++ b/rails/spec/javascript/spec_helper.js
@@ -1,7 +1,7 @@
 // Teaspoon includes some support files, but you can use anything from your own support path too.
 // require support/expect
 // require support/sinon
-// require support/chai
+//= require support/chai
 // require support/chai-jq-0.0.7
 // require support/your-support-file
 //

--- a/rails/spec/teaspoon_env.rb
+++ b/rails/spec/teaspoon_env.rb
@@ -108,10 +108,23 @@ Teaspoon.configure do |config|
   # Selenium Webdriver: https://github.com/modeset/teaspoon/wiki/Using-Selenium-WebDriver
   # BrowserStack Webdriver: https://github.com/modeset/teaspoon/wiki/Using-BrowserStack-WebDriver
   # Capybara Webkit: https://github.com/modeset/teaspoon/wiki/Using-Capybara-Webkit
+  selenium_opts = Selenium::WebDriver::Chrome::Options.new
+  selenium_opts.add_argument('--headless')
+  selenium_opts.add_argument('--disable-gpu')
+  selenium_opts.add_argument('--disable-extensions')
   config.driver_options = {
     client_driver: :chrome,
+    client_driver_opts: {
+      options: {
+        args: [
+          '--headless',
+          '--disable-gpu',
+          '--disable-extensions'
+        ]
+      }
+    },
     selenium_options: {
-      options: Selenium::WebDriver::Chrome::Options.new(args: ['headless', 'disable-gpu'])
+      options: selenium_opts
     }
   }
 


### PR DESCRIPTION
<!--Read comments, before commiting pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->
Closes #32 (replaces it)

### Description
<!-- Please include a summary of the change and which issue is fixed. 
Please also include relevant motivation and context.
Guide questions:
  - What motivated this change (if not already described in an issue)?
  - What alternative solutions did you consider?
  - What are the tradeoffs for your solution?
   
List any dependencies that are required for this change. (gems, js libraries, etc.)

Include anything else we should know about. -->
This adds a rake task that runs both ruby and javascript tests:

```{bash}
bundle exec rake test
```

To enable this, it also enables command-line output of javascript tests.

### Type of change

<!-- Please delete options that are not relevant. -->

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Do we need to do anything else to verify your changes? 
If so, provide instructions (including any relevant configuration) so that 
we can reproduce? -->
