### PR TITLE
Add file upload UI for restoration activity log

### DIFF
--- a/rails/app/controllers/restoration_activity_log_entries_controller.rb
+++ b/rails/app/controllers/restoration_activity_log_entries_controller.rb
@@ -69,6 +69,6 @@ class RestorationActivityLogEntriesController < ApplicationController
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def restoration_activity_log_entry_params
-      params.require(:restoration_activity_log_entry).permit(:cleaned, :percent_filled, :broken_corals, :dead_corals, :dive_id, :nursery_table_id)
+      params.require(:restoration_activity_log_entry).permit(:cleaned, :percent_filled, :broken_corals, :dead_corals, :dive_id, :nursery_table_id, images:[])
     end
 end

--- a/rails/app/views/restoration_activity_log_entries/_form.html.erb
+++ b/rails/app/views/restoration_activity_log_entries/_form.html.erb
@@ -10,6 +10,7 @@
     <%= f.input :dead_corals %>
     <%= f.input :dive_id %>
     <%= f.input :nursery_table_id %>
+    <%= f.input :images, input_html: { multiple: true }%>
   </div>
 
   <div class="form-actions">

--- a/rails/app/views/restoration_activity_log_entries/show.html.erb
+++ b/rails/app/views/restoration_activity_log_entries/show.html.erb
@@ -30,5 +30,12 @@
   <%= @restoration_activity_log_entry.nursery_table_id %>
 </p>
 
+<p>
+  <strong>Images:</strong>
+  <% @restoration_activity_log_entry.images.each do |image| %>
+    <img src="<%= url_for(image) %>"  width="300"/>
+  <% end %>
+</p>
+
 <%= link_to 'Edit', edit_restoration_activity_log_entry_path(@restoration_activity_log_entry) %> |
 <%= link_to 'Back', restoration_activity_log_entries_path %>

--- a/rails/spec/requests/restoration_activity_logs_spec.rb
+++ b/rails/spec/requests/restoration_activity_logs_spec.rb
@@ -1,0 +1,84 @@
+require 'rails_helper'
+require 'support/authentication'
+
+RSpec.describe "Restoration Activity Log", type: :request do
+  include_context "logged in"
+  describe "GET show" do
+    let!(:log_entry) { FactoryBot.create(:restoration_activity_log_entry) }
+
+    it "renders" do
+      get "/restoration_activity_log_entries/#{log_entry.id}"
+
+      expect(response).to be_successful
+    end
+  end
+
+  describe "GET new" do
+    it "succeeds" do
+      get '/restoration_activity_log_entries/new'
+
+      expect(response).to be_successful
+    end
+  end
+
+  describe "POST create" do
+    context "given images" do
+      subject do
+        -> {
+          post '/restoration_activity_log_entries', params: { restoration_activity_log_entry: { images: images } }
+        }
+      end
+
+      let(:images) do
+        [
+          fixture_file_upload(Rails.root.join('spec', 'factories','images', "GOPR3892.JPG")),
+          fixture_file_upload(Rails.root.join('spec', 'factories','images', "GOPR3893.JPG"))
+        ]
+      end
+
+      it "redirects to another page" do
+        subject.call
+        expect(response).to be_redirect
+
+        follow_redirect!
+        expect(response).to be_successful
+      end
+
+      it "adds a log entry" do
+        expect { subject.call }.to change {RestorationActivityLogEntry.count }.by(1)
+      end
+    end
+
+    describe "PUT update" do
+      context "given images" do
+        subject do
+          -> {
+            put "/restoration_activity_log_entries/#{log_entry.id}", params: { restoration_activity_log_entry: { images: images } }
+          }
+        end
+
+        let!(:log_entry) { FactoryBot.create(:restoration_activity_log_entry) }
+
+
+        let(:images) do
+          [
+            fixture_file_upload(Rails.root.join('spec', 'factories','images', "GOPR3892.JPG")),
+            fixture_file_upload(Rails.root.join('spec', 'factories','images', "GOPR3893.JPG"))
+          ]
+        end
+
+        it "redirects to another page" do
+          subject.call
+          expect(response).to be_redirect
+
+          follow_redirect!
+          expect(response).to be_successful
+        end
+
+        it "adds images" do
+          expect { subject.call }.to change { log_entry.images.count }.by(2)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
<!--Read comments, before commiting pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->

### Description
Enabled file uploads for log entries.
<!-- Please include a summary of the change and which issue is fixed. 
Please also include relevant motivation and context.
Guide questions:
  - What motivated this change (if not already described in an issue)?
  - What alternative solutions did you consider?
  - What are the tradeoffs for your solution?
   
List any dependencies that are required for this change. (gems, js libraries, etc.)

Include anything else we should know about. -->

### Type of change

<!-- Please delete options that are not relevant. -->

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?
-If you visit the Edit and New pages you can upload photos
-You can see the photos on the Show page

<!-- Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Do we need to do anything else to verify your changes? 
If so, provide instructions (including any relevant configuration) so that 
we can reproduce? -->

### Screenshots
<!--Optional. Delete if not relevant. 
Include screenshots (before / after) for style changes, highlight 
edited element.-->
![Screen Shot 2019-07-28 at 11 23 28 AM](https://user-images.githubusercontent.com/9014849/62009176-440dab00-b12a-11e9-87b4-e1347fbeb498.png)
