### PR TITLE
Used skipWaiting to replace existing service worker in current client

### DIFF
--- a/rails/app/assets/javascripts/serviceworker-companion.js
+++ b/rails/app/assets/javascripts/serviceworker-companion.js
@@ -4,5 +4,24 @@ if (navigator.serviceWorker) {
       var registrationEvent = new Event('serviceWorkerRegistered');
       document.dispatchEvent(registrationEvent);
       console.log('[Companion]', 'Service worker registered!');
+
+      reg.addEventListener('updatefound', () => {
+        // A wild service worker has appeared in reg.installing!
+        const newWorker = reg.installing;
+    
+        newWorker.state;
+        // "installing" - the install event has fired, but not yet complete
+        // "installed"  - install complete
+        // "activating" - the activate event has fired, but not yet complete
+        // "activated"  - fully active
+        // "redundant"  - discarded. Either failed install, or it's been
+        //                replaced by a newer version
+    
+        newWorker.addEventListener('statechange', () => {
+          console.log(`New Worker State: ${newWorker.state}`)
+  
+        });
+      });
+    
     });
 }

--- a/rails/app/assets/javascripts/serviceworker.js.erb
+++ b/rails/app/assets/javascripts/serviceworker.js.erb
@@ -5,8 +5,10 @@ function onInstall(event) {
   console.log('[Serviceworker]', "Installing!", event);
   event.waitUntil(
     caches.open(CACHE_NAME).then(function prefill(cache) {
+       /* See this pretty chart 
+      https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API/Using_Service_Workers#Basic_architecture */
+      self.skipWaiting()
       return cache.addAll([
-
         // make sure serviceworker.js is not required by application.js
         // if you want to reference application.js from here
         '<%#= asset_path "application.js" %>',


### PR DESCRIPTION
Paired with @Josecc !! New service worker now replaces existing service worker without having to manually unregister the latter. 

Resources we used:
https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API/Using_Service_Workers#Basic_architecture
https://developer.mozilla.org/en-US/docs/Web/API/ServiceWorkerGlobalScope/skipWaiting#Example


### Type of change

<!-- Please delete options that are not relevant. -->

* New feature (non-breaking change which adds functionality)
* Breaking change (fix or feature that would cause existing functionality to not 
work as expected) maybe? See below. 


### How Has This Been Tested?
Added  console logs to confirm state change to activate when a new service worker installed. This will replace the service worker without waiting for client window to close. We would like a review from someone who would know whether this could lead to data loss. 
https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API/Using_Service_Workers#Basic_architecture

### Screenshots
<!--Optional. Delete if not relevant. 
Include screenshots (before / after) for style changes, highlight 
edited element.-->