### PR TITLE
fix form caching

### DIFF
--- a/rails/app/assets/javascripts/serviceworker.js.erb
+++ b/rails/app/assets/javascripts/serviceworker.js.erb
@@ -73,7 +73,14 @@ function onFetch(event) {
 function onMessage(event) {
   console.log('service worker received:', event.data);
   if (event.data.type === 'fetchForms') {
-    event.waitUntil(fetchForms);
+    event.waitUntil(
+      caches.open(CACHE_NAME)
+        .then(function cacheLogForms(cache) {
+          return cache.addAll([
+            '/restoration_activity_log_entries/new',
+          ])
+        })
+    )
   }
 }
 
@@ -81,15 +88,6 @@ self.addEventListener('install', onInstall);
 self.addEventListener('activate', onActivate);
 self.addEventListener('fetch', onFetch);
 self.addEventListener('message', onMessage);
-
-function fetchForms() {
-  console.log("caching forms")
-  caches.open(CACHE_NAME).then(function cacheLogForms(cache) {
-    return cache.addAll([
-      '/restoration_activity_log_entries/new', 
-    ]);
-  })
-}
 
 function writeRequest(request) {
   return request.method === 'POST' ||
@@ -143,7 +141,7 @@ function initWriteDatabase() {
     }
     request.onupgradeneeded = function(event) {
       console.log('upgrading db');
-      // Save the IDBDatabase interface 
+      // Save the IDBDatabase interface
       var db = event.target.result;
 
       // Create an objectStore for this database

--- a/rails/app/javascript/packs/application.js
+++ b/rails/app/javascript/packs/application.js
@@ -19,17 +19,21 @@ console.log('Hello World from Webpacker')
 
 import "controllers"
 
-document.addEventListener('serviceWorkerRegistered', () => {
-  console.log("webpack heard the sw register");
+// document.addEventListener('serviceWorkerRegistered', () => {
+//   console.log("webpack heard the sw register");
 
-  if (navigator.serviceWorker.controller) {
-    fetchForms()
-  } else {
-    navigator.serviceWorker.addEventListener('controllerchange', fetchForms);
-  }
-});
+//   if (navigator.serviceWorker.controller) {
+//     fetchForms()
+//   } else {
+//     navigator.serviceWorker.addEventListener('controllerchange', fetchForms);
+//   }
+// });
 
 function fetchForms() {
   console.log('fetching forms');
   navigator.serviceWorker.controller.postMessage({ type: 'fetchForms' });
 }
+
+navigator.serviceWorker.ready.then(_event => {
+  fetchForms();
+});


### PR DESCRIPTION
### Description
we don't know why inlining form fetching works and returning a promise doesn't,
but we do know that that's how it works.

The demo is imminent. We are moving on.

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
1. Unregister the previous service worker.
2. IN A FRESHLY OPENED TAB, and unfortunately that does matter right now, go to `/restoration_activity_log_entries`.
3. Turn off local server and/or otherwise go offline. Note that Chrome's devtools' offline mode is not 100% trustworthy in terms of unhooking you from the server.
4. Click the "new log entry" link. You should see the log entry form, in spite of being off line.
5. Fill out the form, and submit it.
6. You should now see the form again, but the "pending log entries" message above it should say that one more log entry is pending.