### PR TITLE
Fix service worker issues caused by integration phase

### DIFF
--- a/rails/app/assets/javascripts/serviceworker.js.erb
+++ b/rails/app/assets/javascripts/serviceworker.js.erb
@@ -23,6 +23,7 @@ function onInstall(event) {
 }
 
 function onActivate(event) {
+  console.log("different");
   console.log('[Serviceworker]', "Activating!", event);
   event.waitUntil(
     caches.keys().then(function(cacheNames) {
@@ -73,7 +74,7 @@ function onFetch(event) {
 }
 
 function onMessage(event) {
-  console.log('service worker received:', event.data);
+  console.log('service worker message', event.data);
   if (event.data.type === 'fetchForms') {
     event.waitUntil(
       caches.open(CACHE_NAME)

--- a/rails/app/controllers/application_controller.rb
+++ b/rails/app/controllers/application_controller.rb
@@ -11,9 +11,9 @@ class ApplicationController < ActionController::Base
     I18n.locale = locale if I18n.available_locales.include?(locale)
   end
 
-  def default_url_options(options = {})
-    options.merge(locale: I18n.locale)
-  end
+  # def default_url_options(options = {})
+  #   options.merge(locale: I18n.locale)
+  # end
 
   protected
 

--- a/rails/app/javascript/packs/application.js
+++ b/rails/app/javascript/packs/application.js
@@ -19,15 +19,15 @@ console.log('Hello World from Webpacker')
 
 import "controllers"
 
-// document.addEventListener('serviceWorkerRegistered', () => {
-//   console.log("webpack heard the sw register");
+document.addEventListener('serviceWorkerRegistered', () => {
+  console.log("webpack heard the sw register");
 
-//   if (navigator.serviceWorker.controller) {
-//     fetchForms()
-//   } else {
-//     navigator.serviceWorker.addEventListener('controllerchange', fetchForms);
-//   }
-// });
+  if (navigator.serviceWorker.controller) {
+    fetchForms()
+  } else {
+    navigator.serviceWorker.addEventListener('controllerchange', fetchForms);
+  }
+});
 
 function fetchForms() {
   console.log('fetching forms');
@@ -35,5 +35,9 @@ function fetchForms() {
 }
 
 navigator.serviceWorker.ready.then(_event => {
-  fetchForms();
+  if (navigator.serviceWorker.controller) {
+    fetchForms()
+  } else {
+    navigator.serviceWorker.addEventListener('controllerchange', fetchForms);
+  }
 });

--- a/rails/app/views/restoration_activity_log_entries/_form.html.erb
+++ b/rails/app/views/restoration_activity_log_entries/_form.html.erb
@@ -1,4 +1,3 @@
-
 <%= simple_form_for(@restoration_activity_log_entry) do |f| %>
   <%= f.error_notification %>
   <%= f.error_notification message: f.object.errors[:base].to_sentence if f.object.errors[:base].present? %>


### PR DESCRIPTION
**This breaks internationalization. That will need to be fixed in a separate PR.**

### Description
During the integration rush, the service worker stopped working.

This is a quick fix for the proximate issues.

1. Re-impose correct ordering of service worker related events -- this had gotten crossed up between the two SW pairs in merge.
2. Remove querystring locales, which break the service worker's router.

### Type of change

* Bug fix (non-breaking change which fixes an issue)
* Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How Has This Been Tested?

1. Go to /restoration_activity_event_log_entries/new
2. Stop Rails server
3. Create log entry

It should increment the number of queued log entries.