### PR TITLE
removed destroy buttons from restoration activity logs

### DIFF
--- a/rails/app/views/restoration_activity_log_entries/index.html.erb
+++ b/rails/app/views/restoration_activity_log_entries/index.html.erb
@@ -13,7 +13,6 @@
         <div class="card-footer restoration-index">
           <a href="#" class="btn btn-primary">Show</a>
           <a href="#" class="btn btn-primary">Edit</a>
-          <a href="#" class="btn btn-primary">Destroy</a>
         </div>
       </div>
     </div>


### PR DESCRIPTION

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),

Resolves #62 

### Description

This line of code was removed from rails/app/views/restoration_activity_log_entries
          <a href="#" class="btn btn-primary">Destroy</a>

Meaning the the ability to remove old log entries is now disabled
   
### Type of change

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

Tested on my local machine and works fine along with.
