### PR TITLE
Fixed nursery table creation bug

### DIFF
--- a/rails/app/views/nursery_tables/_form.html.erb
+++ b/rails/app/views/nursery_tables/_form.html.erb
@@ -18,7 +18,7 @@
 
   <div class="field">
     <%= form.label :zone %>
-    <%= form.select :zone_id, options_from_collection_for_select(Zone.all, :name, :name) %>
+    <%= form.select :zone_id, options_from_collection_for_select(Zone.all, :id, :name) %>
   </div>
 
   <div class="field">


### PR DESCRIPTION

Resolves #67 

### Description
Creating a "nursery table" would fail to save as the "nursery_table form" could not locate the zone.

### Type of change


* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Tested on my local machine and works fine. 

### Screenshots
<!--Optional. Delete if not relevant. 
Include screenshots (before / after) for style changes, highlight 
edited element.-->


Before
![63039080-86f0b200-be90-11e9-94c5-2f210f17109e](https://user-images.githubusercontent.com/51298718/63049355-60526b80-bed0-11e9-8931-f5d77ca48344.png)

After
![Screenshot 2019-08-14 at 20 15 17](https://user-images.githubusercontent.com/51298718/63049332-50d32280-bed0-11e9-82b1-9e3667d90008.png)


