### PR TITLE
Nursery table feature

### DIFF
--- a/rails/Gemfile
+++ b/rails/Gemfile
@@ -86,4 +86,4 @@ gem "serviceworker-rails", "~> 0.6"
 gem "faker", "~> 1.9"
 
 # Used for pagination
-gem 'will_paginate', '~> 3.1.0'
+gem "will_paginate", "~> 3.1.0"

--- a/rails/Gemfile
+++ b/rails/Gemfile
@@ -84,3 +84,7 @@ gem "rails-i18n"
 gem "serviceworker-rails", "~> 0.6"
 
 gem "faker", "~> 1.9"
+
+## Gemfile for Rails 3+, Sinatra, and Merb
+gem 'will_paginate', '~> 3.1.0'
+gem 'will_paginate-bootstrap' 

--- a/rails/Gemfile
+++ b/rails/Gemfile
@@ -85,6 +85,5 @@ gem "serviceworker-rails", "~> 0.6"
 
 gem "faker", "~> 1.9"
 
-## Gemfile for Rails 3+, Sinatra, and Merb
+# Used for pagination
 gem 'will_paginate', '~> 3.1.0'
-gem 'will_paginate-bootstrap' 

--- a/rails/Gemfile.lock
+++ b/rails/Gemfile.lock
@@ -280,6 +280,9 @@ GEM
     websocket-driver (0.7.1)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.4)
+    will_paginate (3.1.7)
+    will_paginate-bootstrap (1.0.2)
+      will_paginate (>= 3.0.3)
     xpath (3.2.0)
       nokogiri (~> 1.8)
 
@@ -321,9 +324,11 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)
   webpacker
+  will_paginate (~> 3.1.0)
+  will_paginate-bootstrap
 
 RUBY VERSION
    ruby 2.6.3p62
 
 BUNDLED WITH
-   2.0.1
+   2.0.2

--- a/rails/Gemfile.lock
+++ b/rails/Gemfile.lock
@@ -281,8 +281,6 @@ GEM
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.4)
     will_paginate (3.1.7)
-    will_paginate-bootstrap (1.0.2)
-      will_paginate (>= 3.0.3)
     xpath (3.2.0)
       nokogiri (~> 1.8)
 
@@ -325,7 +323,6 @@ DEPENDENCIES
   web-console (>= 3.3.0)
   webpacker
   will_paginate (~> 3.1.0)
-  will_paginate-bootstrap
 
 RUBY VERSION
    ruby 2.6.3p62

--- a/rails/app/controllers/nursery_tables_controller.rb
+++ b/rails/app/controllers/nursery_tables_controller.rb
@@ -10,7 +10,7 @@ class NurseryTablesController < ApplicationController
   # GET /nursery_tables/1
   # GET /nursery_tables/1.json
   def show
-    @nursery_restoration_activity = @nursery_table.restoration_activity_log_entries.paginate(:page => params[:page], :per_page => 1).order('id DESC')
+    @nursery_restoration_activity = @nursery_table.restoration_activity_log_entries.paginate(page: params[:page], per_page: 1).order("id DESC")
   end
 
   # GET /nursery_tables/new

--- a/rails/app/controllers/nursery_tables_controller.rb
+++ b/rails/app/controllers/nursery_tables_controller.rb
@@ -10,10 +10,7 @@ class NurseryTablesController < ApplicationController
   # GET /nursery_tables/1
   # GET /nursery_tables/1.json
   def show
-    # @nursery_table = NurseryTable.paginate(page: 1, per_page: 2).last.restoration_activity_log_entries
-    # @nursery_table = NurseryTable.first.restoration_activity_log_entries.paginate(page:1, per_page: 1)
-    
-  
+    @nursery_restoration_activity = @nursery_table.restoration_activity_log_entries.paginate(:page => params[:page], :per_page => 1)
   end
 
   # GET /nursery_tables/new

--- a/rails/app/controllers/nursery_tables_controller.rb
+++ b/rails/app/controllers/nursery_tables_controller.rb
@@ -10,7 +10,7 @@ class NurseryTablesController < ApplicationController
   # GET /nursery_tables/1
   # GET /nursery_tables/1.json
   def show
-    @nursery_restoration_activity = @nursery_table.restoration_activity_log_entries.paginate(:page => params[:page], :per_page => 1)
+    @nursery_restoration_activity = @nursery_table.restoration_activity_log_entries.paginate(:page => params[:page], :per_page => 1).order('id DESC')
   end
 
   # GET /nursery_tables/new

--- a/rails/app/controllers/nursery_tables_controller.rb
+++ b/rails/app/controllers/nursery_tables_controller.rb
@@ -10,6 +10,10 @@ class NurseryTablesController < ApplicationController
   # GET /nursery_tables/1
   # GET /nursery_tables/1.json
   def show
+    # @nursery_table = NurseryTable.paginate(page: 1, per_page: 2).last.restoration_activity_log_entries
+    # @nursery_table = NurseryTable.first.restoration_activity_log_entries.paginate(page:1, per_page: 1)
+    
+  
   end
 
   # GET /nursery_tables/new

--- a/rails/app/models/nursery_table.rb
+++ b/rails/app/models/nursery_table.rb
@@ -5,5 +5,6 @@
 # lists when filling out log entries.
 class NurseryTable < ApplicationRecord
   belongs_to :zone
+  has_many :restoration_activity_log_entries
   validates :capacity, numericality: { greater_than_or_equal_to: 1 }
 end

--- a/rails/app/views/nursery_tables/show.html.erb
+++ b/rails/app/views/nursery_tables/show.html.erb
@@ -24,7 +24,7 @@
 
 
 
-  <% @nursery_table.restoration_activity_log_entries.each do |entry| %>
+  <% @nursery_restoration_activity.each do |entry| %>
     <br>
     <div class="col-4">
       <div class="card text-center">
@@ -42,9 +42,8 @@
     </div>
   <% end %>
 
-  <%= will_paginate @nursery_table.restoration_activity_log_entries.paginate(page: 1, per_page: 1), next_label: "Newer", :page_links => false %>
-
 </p>
+<%= will_paginate @nursery_restoration_activity %>
 
 
 <%= link_to t('.edit'), edit_nursery_table_path(@nursery_table) %> |

--- a/rails/app/views/nursery_tables/show.html.erb
+++ b/rails/app/views/nursery_tables/show.html.erb
@@ -14,6 +14,38 @@
   <strong><%= t('.name') %>:</strong>
   <%= @nursery_table.name %>
 </p>
+<br>
+<br>
+
+<p>
+  <strong><%= t('.Restoration Activity Logs') %>:</strong>
+  <br>
+  <br>
+
+
+
+  <% @nursery_table.restoration_activity_log_entries.each do |entry| %>
+    <br>
+    <div class="col-4">
+      <div class="card text-center">
+        <div class="card-body restoration-index">
+          <h5 class="card-title"><%= entry.nursery_table.name %></h5>
+          <h6 class="card-subtitle mb-2 text-muted"><%= entry.created_at %></h6>
+          <p class="card-text">The table is <%= entry.percent_filled %> percent full. There are <%= entry.bleached_corals %> fragmented corals and <%= entry.dead_corals %> dead corals.</p>
+          <p class="card-text text-muted">Was the nursery table cleaned? <%= entry.cleaned %></p>
+        </div>
+        <div class="card-footer restoration-index">
+          <a href="#" class="btn btn-primary">Show</a>
+          <a href="#" class="btn btn-primary">Edit</a>
+        </div>
+      </div>
+    </div>
+  <% end %>
+
+  <%= will_paginate @nursery_table.restoration_activity_log_entries.paginate(page: 1, per_page: 1), next_label: "Newer", :page_links => false %>
+
+</p>
+
 
 <%= link_to t('.edit'), edit_nursery_table_path(@nursery_table) %> |
 <%= link_to t('.back'), nursery_tables_path %>


### PR DESCRIPTION
# Checklist:

- I have performed a self-review of my own code,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),

Resolves #63  <!--fill issue number-->

### Description

This change has added to the nursery table dashboard by showing most-recent-first history of restoration activities taken place at the nursery.

New gems that are required
gem 'will_paginate', '~> 3.1.0'

### Type of change

* Breaking change (fix or feature that would cause existing functionality to not 
work as expected)

### How Has This Been Tested?

I have created new zones, nursery tables and activity entry logs and no problems on my local machine.

### Screenshots
<!--Optional. Delete if not relevant. 
Include screenshots (before / after) for style changes, highlight 
edited element.-->

before
![Screenshot 2019-08-14 at 21 33 09](https://user-images.githubusercontent.com/51298718/63126840-bb579180-bfa8-11e9-9eff-9c983ecea57f.png)

after 

![Screenshot 2019-08-15 at 22 05 47](https://user-images.githubusercontent.com/51298718/63126900-e2ae5e80-bfa8-11e9-8660-b5a77b199ec9.png)

