### PR TITLE
Bug fix: The restoration activity log index broke if there were any log entrie…

### DIFF
--- a/rails/app/models/restoration_activity_log_entry.rb
+++ b/rails/app/models/restoration_activity_log_entry.rb
@@ -8,4 +8,8 @@ class RestorationActivityLogEntry < ApplicationRecord
   belongs_to :nursery_table, optional: true
   belongs_to :dive, optional: true
   has_many_attached :images
+
+  def table_name
+    nursery_table.present? ? nursery_table.name : "Unassigned"
+  end
 end

--- a/rails/app/views/restoration_activity_log_entries/index.html.erb
+++ b/rails/app/views/restoration_activity_log_entries/index.html.erb
@@ -5,7 +5,7 @@
     <div class="col-4">
       <div class="card text-center">
         <div class="card-body restoration-index">
-          <h5 class="card-title"><%= entry.nursery_table.name %></h5>
+          <h5 class="card-title"><%= entry.nursery_table&.name %></h5>
           <h6 class="card-subtitle mb-2 text-muted"><%= l(entry.created_at) %></h6>
           <p class="card-text">
             <%= t('.percent_filled_message', percent_filled: entry.percent_filled) %>

--- a/rails/app/views/restoration_activity_log_entries/index.html.erb
+++ b/rails/app/views/restoration_activity_log_entries/index.html.erb
@@ -5,7 +5,7 @@
     <div class="col-4">
       <div class="card text-center">
         <div class="card-body restoration-index">
-          <h5 class="card-title"><%= entry.nursery_table&.name %></h5>
+          <h5 class="card-title"><%= entry.table_name %></h5>
           <h6 class="card-subtitle mb-2 text-muted"><%= l(entry.created_at) %></h6>
           <p class="card-text">
             <%= t('.percent_filled_message', percent_filled: entry.percent_filled) %>

--- a/rails/spec/models/restoration_activity_log_entry_spec.rb
+++ b/rails/spec/models/restoration_activity_log_entry_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 RSpec.describe RestorationActivityLogEntry do
   log = FactoryBot.build(:restoration_activity_log_entry)
+  table = FactoryBot.build(:nursery_table)
 
   def attach_jpeg_image(log, filename)
     log.images.attach(
@@ -28,6 +29,18 @@ RSpec.describe RestorationActivityLogEntry do
       attach_jpeg_image(log, "GOPR3901.JPG")
       attach_jpeg_image(log, "GOPR3902.JPG")
       expect(log.images.size).to eq 8
+    end
+  end
+
+  describe "table_name" do
+    it "is Unassigned if no nursery table present" do
+      expect(log.table_name).to eq("Unassigned")
+    end
+
+    it "is nursery table name if available" do
+      log.nursery_table = table
+
+      expect(log.table_name).to eq(table.name)
     end
   end
 end


### PR DESCRIPTION
…s that we not associated with a nursery table. An alternative to this quick fix is to enforce the presence of a nursery table id (it is marked optional: true in the restoration activity log entry model). Would also need to figure out why the nursery table is not being assigned in the create new log form.

<!--Read comments, before commiting pull request read checklist again



### Description
<!-- Please include a summary of the change and which issue is fixed. 
Please also include relevant motivation and context.
Guide questions:
  - What motivated this change (if not already described in an issue)?
  - What alternative solutions did you consider?
  - What are the tradeoffs for your solution?
   
List any dependencies that are required for this change. (gems, js libraries, etc.)

Include anything else we should know about. -->

### Type of change

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Do we need to do anything else to verify your changes? 
If so, provide instructions (including any relevant configuration) so that 
we can reproduce? -->
Tested manually in the browser and added specs to confirm that table_name produced the desired output in both major cases. 

### Screenshots
<!--Optional. Delete if not relevant. 
Include screenshots (before / after) for style changes, highlight 
edited element.-->