### PR TITLE
Implement internationalization based on URL path not query string

### DIFF
--- a/rails/Gemfile
+++ b/rails/Gemfile
@@ -18,6 +18,8 @@ gem "webpacker"
 # See https://github.com/rails/execjs#readme for more supported runtimes
 # gem 'mini_racer', platforms: :ruby
 gem "coffee-rails"
+# Use rack-rewrite to ensure default locale is always used
+gem "rack-rewrite", "~> 1.5.1"
 
 # Turbolinks makes navigating your web application faster. Read more: https://github.com/turbolinks/turbolinks
 gem "turbolinks", "~> 5"

--- a/rails/Gemfile.lock
+++ b/rails/Gemfile.lock
@@ -151,6 +151,7 @@ GEM
       rack
     rack-proxy (0.6.5)
       rack
+    rack-rewrite (1.5.1)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (5.2.3)
@@ -306,6 +307,7 @@ DEPENDENCIES
   pg (>= 0.18, < 2.0)
   pry
   puma (~> 3.11)
+  rack-rewrite (~> 1.5.1)
   rails (~> 5.2.3)
   rails-i18n
   rspec-rails
@@ -329,4 +331,4 @@ RUBY VERSION
    ruby 2.6.3p62
 
 BUNDLED WITH
-   2.0.1
+   2.0.2

--- a/rails/app/assets/stylesheets/application.scss
+++ b/rails/app/assets/stylesheets/application.scss
@@ -166,6 +166,10 @@ $highlight-text: #C06D19;
     font-size: 1.8rem;
   }
 
+  #active-lang {
+    color: $white;
+  }
+
   // Buttons //
 
   a.btn {

--- a/rails/app/controllers/application_controller.rb
+++ b/rails/app/controllers/application_controller.rb
@@ -5,7 +5,7 @@ class ApplicationController < ActionController::Base
   around_action :set_locale
 
   protected
-  
+
   def set_locale(&action)
     locale = params[:locale].to_s.strip.to_sym
     if (!I18n.available_locales.include?(locale))
@@ -18,8 +18,6 @@ class ApplicationController < ActionController::Base
     # options.merge(locale: I18n.locale)
     { locale: I18n.locale == I18n.default_locale ? I18n.default_locale : I18n.locale }
   end
-
-  protected
 
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up, keys: %i[name email password password_confirmation])

--- a/rails/app/controllers/application_controller.rb
+++ b/rails/app/controllers/application_controller.rb
@@ -2,18 +2,22 @@ class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
   before_action :authenticate_user!
 
-  before_action :set_locale
+  around_action :set_locale
 
-  def set_locale
-    I18n.locale = I18n.default_locale
+  protected
+  
+  def set_locale(&action)
     locale = params[:locale].to_s.strip.to_sym
-
-    I18n.locale = locale if I18n.available_locales.include?(locale)
+    if (!I18n.available_locales.include?(locale))
+      locale = I18n.default_locale
+    end
+    I18n.with_locale(locale, &action)
   end
 
-  # def default_url_options(options = {})
-  #   options.merge(locale: I18n.locale)
-  # end
+  def default_url_options(options = {})
+    # options.merge(locale: I18n.locale)
+    { locale: I18n.locale == I18n.default_locale ? I18n.default_locale : I18n.locale }
+  end
 
   protected
 

--- a/rails/app/views/dives/new.html.erb
+++ b/rails/app/views/dives/new.html.erb
@@ -1,6 +1,6 @@
-<h1><%=t '.title' %></h1>
+<h1><%= t('.title') %></h1>
 
-<p><%=t '.checklist_preface' %></p>
+<p><%= t('.checklist_preface') %></p>
 
 <%= simple_form_for dive do |f| %>
   <%= f.input :i_have_been_responsible, as: :boolean %>

--- a/rails/app/views/dives/show.html.erb
+++ b/rails/app/views/dives/show.html.erb
@@ -1,7 +1,7 @@
-<h1><%=t '.title', dive_id: dive.id %></h1>
+<h1><%= t('.title', dive_id: dive.id) %></h1>
 
 <%- if dive.finished? %>
-  <%=t '.finished_at_log_message', finished_at: dive.finished_at.to_formatted_s(:db) %>
+  <%= t('.finished_at_log_message', finished_at: dive.finished_at.to_formatted_s(:db)) %>
 <%- else %>
 
 

--- a/rails/app/views/layouts/application.html.erb
+++ b/rails/app/views/layouts/application.html.erb
@@ -49,6 +49,7 @@
               <%= link_to t('.logout'), destroy_user_session_path, method: :delete, data: { confirm: 'Please confirm you wish to log out.' }, :class =>"nav-link" %>
             </li>
           <% end %>
+          <%= render 'shared/locale_links' %>
         </nav>
       </header>
     </div> <%# End navbar %>

--- a/rails/app/views/shared/_locale_links.html.erb
+++ b/rails/app/views/shared/_locale_links.html.erb
@@ -1,0 +1,10 @@
+  <li class="nav-item">
+    Language:&nbsp;
+    <% locale_links = I18n.available_locales.map do |locale|
+    <<-ENDHTML
+    #{link_to locale.to_s.upcase, request.parameters.merge(locale: locale.to_s), className: "nav-link", id: locale.to_s == request.parameters['locale'] ? "active-lang" : ""}
+
+    ENDHTML
+    end %>
+    <%= raw(locale_links.join('&nbsp;|&nbsp;')) %>
+  </li>

--- a/rails/config/application.rb
+++ b/rails/config/application.rb
@@ -43,7 +43,7 @@ module Coral
       }.join("|")
     }"
     default_locale = config.i18n.default_locale.to_s
-    puts locales_neg_regex
+
     config.middleware.insert_before(Rack::Runtime, Rack::Rewrite) do
       rewrite %r{^(https?\:\/\/(?:[\w\.]+)(?::\d+)?)?((?!#{locales_neg_regex})\/[\w\/\?,\-=%+]+)$},
         "$1/#{default_locale}/$2"

--- a/rails/config/locales/fr.yml
+++ b/rails/config/locales/fr.yml
@@ -42,6 +42,7 @@ fr:
       title: "En plongée #%{dive_id}"
       finished_at_log_message: "Terminé à %{finished_at}."
       finish_button: "Terminer la plongée"
+      log_restoration: "Enregistrer une activité de restauration"
   nursery_tables:
     index:
       title: "Tables de Pépinière"

--- a/rails/config/routes.rb
+++ b/rails/config/routes.rb
@@ -1,30 +1,34 @@
 Rails.application.routes.draw do
-  root to: "home#index"
+  get "/*path", to: redirect("/#{I18n.default_locale}/%{path}"),
+    constraints: {
+      path: %r{(?!(#{I18n.available_locales.join('|')})).*}
+    }
+    # I18n.available_locales.map(&:to_s).includes?(path.split('/').first)
 
-  # User routes
-  devise_for :users
-  resources :users, only: %i[index show]
-  devise_scope :user do
-    get "sign_in", to: "devise/sessions#new"
-    get "sign_up", to: "devise/registrations#new"
-  end
-
-  resources :restoration_activity_log_entries
-  resources :nursery_tables
-  resources :zones
-  resources :dives, only: %i[new create show] do
-    post :finish, on: :member
-    resources :restoration_activity_log_entries, only: %i[new create]
-  end
-
-  devise_scope :user do
-    get "sign_in", to: "devise/sessions#new"
-    get "sign_up", to: "devise/registrations#new"
-  end
-
-  resources :users, only: %i[index show]
-
-  scope "(:locale)", locale: /en|fr/ do
+  scope ":locale", locale: /#{I18n.available_locales.join("|")}/ do
     root to: "home#index"
+
+    # User routes
+    devise_for :users
+    resources :users, only: %i[index show]
+    devise_scope :user do
+      get "sign_in", to: "devise/sessions#new"
+      get "sign_up", to: "devise/registrations#new"
+    end
+
+    resources :restoration_activity_log_entries
+    resources :nursery_tables
+    resources :zones
+    resources :dives, only: %i[new create show] do
+      post :finish, on: :member
+      resources :restoration_activity_log_entries, only: %i[new create]
+    end
+
+    devise_scope :user do
+      get "sign_in", to: "devise/sessions#new"
+      get "sign_up", to: "devise/registrations#new"
+    end
+
+    resources :users, only: %i[index show]
   end
 end

--- a/rails/config/routes.rb
+++ b/rails/config/routes.rb
@@ -1,10 +1,4 @@
 Rails.application.routes.draw do
-  get "/*path", to: redirect("/#{I18n.default_locale}/%{path}"),
-    constraints: {
-      path: %r{(?!(#{I18n.available_locales.join('|')})).*}
-    }
-    # I18n.available_locales.map(&:to_s).includes?(path.split('/').first)
-
   scope ":locale", locale: /#{I18n.available_locales.join("|")}/ do
     root to: "home#index"
 

--- a/rails/spec/helpers.rb
+++ b/rails/spec/helpers.rb
@@ -1,0 +1,8 @@
+module Helpers
+  def locale_path_prefixes
+    I18n.available_locales.map{ |l| "/#{l}" } << ""
+  end
+  def default_locale
+    I18n.default_locale
+  end
+end

--- a/rails/spec/rails_helper.rb
+++ b/rails/spec/rails_helper.rb
@@ -8,6 +8,7 @@ require "rspec/rails"
 # Add additional requires below this line. Rails is not loaded until this point!
 
 require_relative "./support/capybara"
+require "./spec/helpers"
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
@@ -69,4 +70,6 @@ RSpec.configure do |config|
     Capybara.server_port = 4000
     Capybara.app_host = "http://web:4000"
   end
+
+  config.include Helpers
 end

--- a/rails/spec/requests/dives_spec.rb
+++ b/rails/spec/requests/dives_spec.rb
@@ -1,61 +1,72 @@
 require "rails_helper"
 require "support/authentication"
 
-RSpec.describe "Dives", type: :request do
+RSpec.describe "Dives", type: :request, focus: true do
   include_context "logged in"
   describe "GET show" do
     let!(:dive) { FactoryBot.create(:dive) }
 
     it "renders the dive hub" do
-      get "/dives/#{dive.id}"
-
-      expect(response).to be_successful
+      locale_path_prefixes.each do |locale|
+        get "#{locale}/dives/#{dive.id}"
+        expect(response).to be_successful
+      end
     end
   end
 
   describe "GET new" do
     it "succeeds" do
-      get "/dives/new"
-
-      expect(response).to be_successful
+      locale_path_prefixes.each do |locale|
+        get "#{locale}/dives/new"
+        expect(response).to be_successful
+      end
     end
   end
 
   describe "POST create" do
     context "given a complete checklist" do
       subject do
-        lambda {
-          post "/dives", params: { dive: { i_have_been_responsible: 1 } }
+        lambda { |locale|
+          post_path = "#{locale}/dives"
+          post post_path, params: { dive: { i_have_been_responsible: 1 } }
         }
       end
 
       it "redirects to the dive page" do
-        subject.call
-        expect(response).to be_redirect
+        locale_path_prefixes.each do |locale|
+          subject.call(locale)
+          expect(response).to be_redirect
 
-        follow_redirect!
-        expect(response).to be_successful
+          follow_redirect!
+          expect(response).to be_successful
+        end
       end
 
       it "creates the dive" do
-        expect { subject.call }.to change { Dive.count }.by(1)
+        locale_path_prefixes.each do |locale|
+          expect { subject.call(locale) }.to change { Dive.count }.by(1)
+        end
       end
     end
 
     context "given an incomplete checklist" do
       subject do
-        lambda {
-          post "/dives", params: { dive: { i_have_been_responsible: nil } }
+        lambda { |locale|
+          post "#{locale}/dives", params: { dive: { i_have_been_responsible: nil } }
         }
       end
 
       it "does not create the dive" do
-        expect { subject.call }.not_to change(Dive, :count)
+        locale_path_prefixes.each do |locale|
+          expect { subject.call(locale) }.not_to change(Dive, :count)
+        end
       end
 
       it "renders an error page" do
-        subject.call
-        expect(response.body).to match(/can&#39;t be blank/)
+        locale_path_prefixes.each do |locale|
+          subject.call(locale)
+          expect(response.body).to match(/can&#39;t be blank/)
+        end
       end
     end
   end
@@ -64,24 +75,29 @@ RSpec.describe "Dives", type: :request do
     let!(:dive) { FactoryBot.create(:dive) }
 
     subject do
-      lambda {
+      lambda { |locale|
         post "/dives/#{dive.id}/finish"
       }
     end
 
     it "redirects to the dive page" do
-      subject.call
-      expect(response).to be_redirect
+      locale_path_prefixes.each do |locale|
+        subject.call(locale)
+        expect(response).to be_redirect
 
-      follow_redirect!
-      expect(response).to be_successful
+        follow_redirect!
+        expect(response).to be_successful
+      end
     end
 
     it "marks the dive as finished" do
-      subject.call
+      locale_path_prefixes.each do |locale|
+        subject.call(locale)
 
-      dive.reload
-      expect(dive.finished_at).not_to be_nil
+        dive.reload
+        follow_redirect!
+        expect(dive.finished_at).not_to be_nil
+      end
     end
   end
 end

--- a/rails/spec/requests/home_spec.rb
+++ b/rails/spec/requests/home_spec.rb
@@ -4,7 +4,6 @@ RSpec.describe "home", type: :request do
   include_context "logged in"
   it "can render the root page" do
     get "/"
-    puts response.inspect
     expect(response).to be_successful
 
     sign_out current_user
@@ -14,8 +13,6 @@ RSpec.describe "home", type: :request do
   end
   xit "can render a locale-specific root page" do
     locale_path_prefixes.each do |locale|
-      puts locale
-      puts "Getting #{locale}/"
       get "#{locale}/"
       expect(response).to be_successful
 

--- a/rails/spec/requests/home_spec.rb
+++ b/rails/spec/requests/home_spec.rb
@@ -4,12 +4,25 @@ RSpec.describe "home", type: :request do
   include_context "logged in"
   it "can render the root page" do
     get "/"
-
+    puts response.inspect
     expect(response).to be_successful
 
     sign_out current_user
     get "/"
 
-    expect(response).to redirect_to("/users/sign_in")
+    expect(response).to redirect_to("/#{default_locale}/users/sign_in")
+  end
+  xit "can render a locale-specific root page" do
+    locale_path_prefixes.each do |locale|
+      puts locale
+      puts "Getting #{locale}/"
+      get "#{locale}/"
+      expect(response).to be_successful
+
+      sign_out current_user
+      get "#{locale}/"
+
+      expect(response).to redirect_to("#{locale}/users/sign_in")
+    end
   end
 end

--- a/rails/spec/requests/nursery_tables_spec.rb
+++ b/rails/spec/requests/nursery_tables_spec.rb
@@ -11,13 +11,13 @@ RSpec.describe "Nursery Tables", type: :request do
     let!(:zone) { FactoryBot.create(:zone) }
 
     it "renders the nursery table" do
-      get nursery_tables_path
+      get nursery_tables_path(locale: default_locale)
 
       expect(response).to be_successful
     end
 
     it "allows to create nursery table" do
-      post nursery_tables_path, params: { nursery_table: { capacity: 24, name: "Blah", zone: zone } }
+      post nursery_tables_path(locale: default_locale), params: { nursery_table: { capacity: 24, name: "Blah", zone: zone } }
 
       expect(response).to have_http_status(200)
     end


### PR DESCRIPTION
<!--Read comments, before commiting pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->

Resolves #74 <!--fill issue number-->

### Description
<!-- Please include a summary of the change and which issue is fixed. 
Please also include relevant motivation and context.
Guide questions:
  - What motivated this change (if not already described in an issue)?
  - What alternative solutions did you consider?
  - What are the tradeoffs for your solution?
   
List any dependencies that are required for this change. (gems, js libraries, etc.)

Include anything else we should know about. -->
This modifies the way locale is handled for internationalization in the following way:

* Locale is specified as a scope on the route, and thus a prefix on the URL
* Default scope is implemented via a redirect prior to the locale scope in the routes file (using a path glob, which should work for any existing route, but it's failing the request tests... see below)
* Locale links have been added that reload the current page with the selected locale (updating the route along the way)

I've tested this a variety of ways, and all seems to work under normal online circumstances.

@bhaibel @LizPrescott @that-jill I'll need help understanding how this can help us to do offline work. If you all can dive into this PR and validate that it will actually help us with the service worker situation, I'd appreciate it.

I'm using `Rack::Rewrite` to enable non-locale-scoped paths to load as normal, but load with the default locale in context, so that generated links/routes from that page will include the default context. This seemed like the cleanest way to achieve that. Happy to discuss if that causes problems.

Also, for anyone else reviewing, I'm not a UI person. I'm sure there's a better way of doing that partial view in `app/views/shared/_locale_links.html.erb`, but I'm rusty on my rails view helpers and couldn't figure it out. It's also 2am, so maybe that's part of it. Anyway, help is welcomed there too.

### Type of change

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)
* Breaking change (fix or feature that would cause existing functionality to not 
work as expected)
* This change requires a documentation update  -- maybe for offline stuff? don't know.

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Do we need to do anything else to verify your changes? 
If so, provide instructions (including any relevant configuration) so that 
we can reproduce? -->

One remaining request test is failing, but that's because what it's testing is not correct. (New dive POST.) That's outside the scope of this change, and I don't think I broke that, so I'm leaving it for now.

There's another test for locale-context homepage renders that I added but left skipped. It's brittle at the moment, and I'd like to work on it more before enabling it. I'm leaving it there so there's a reminder to do something on it.

### Screenshots
<!--Optional. Delete if not relevant. 
Include screenshots (before / after) for style changes, highlight 
edited element.-->