### PR TITLE
include request method, headers, and body in indexeddb

### DIFF
--- a/rails/app/assets/javascripts/serviceworker.js.erb
+++ b/rails/app/assets/javascripts/serviceworker.js.erb
@@ -115,22 +115,45 @@ function delayRequest(request) {
     .catch(console.error);
 }
 
+function serializeRequestAsWrite(request) {
+  return new Promise(function(resolve, reject) {
+    var headers = {};
+    for (var header of request.headers.entries()) {
+      headers[header[0]] = header[1];
+    }
+
+    var serialized = {
+      url: request.url,
+      headers: headers,
+      method: request.method,
+    };
+
+    if (request.method !== 'GET' && request.method !== 'HEAD') {
+      return request.clone().text().then(function(body) {
+        serialized.body = body;
+        return resolve(serialized);
+      });
+    } else {
+      return resolve(serialized);
+    }
+  });
+}
+
 function storeRequestAsWrite(db, request) {
   return new Promise((resolve, reject) => {
-    var requestKey = (new Date()).toISOString();
-    var storableRequest = {
-      url: request.url,
-    };
-    console.log('storable request', storableRequest);
-    var dbAdd = db.transaction(["writes"], 'readwrite')
-      .objectStore("writes")
-      .add({
-        key: requestKey,
-        request: storableRequest,
-        status: 'queued',
-      });
-    dbAdd.onsuccess = resolve;
-    dbAdd.onerror = reject;
+    serializeRequestAsWrite(request).then(function(storableRequest) {
+      console.log('storable request', storableRequest);
+      var requestKey = (new Date()).toISOString();
+      var dbAdd = db.transaction(["writes"], 'readwrite')
+        .objectStore("writes")
+        .add({
+          key: requestKey,
+          request: storableRequest,
+          status: 'queued',
+        });
+      dbAdd.onsuccess = resolve;
+      dbAdd.onerror = reject;
+    });
   });
 }
 


### PR DESCRIPTION
### Description

In order to replay a deferred request to add a record to the database, we need
at least the url and method (to dispatch to the correct controller action), the
headers (to satisfy authentication requirements), and the body. Before this
change we only stored the url in indexeddb, and after this change we will also
store the method, headers, and body.

A more general example can be seen at https://serviceworke.rs/request-deferrer_service-worker_doc.html (`function serialize`).

### Type of change

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

* Load `/restoration_activity_log_entries/new` in a browser (I used Chromium v76) while the server is running to reload javascripts.
* Turn off the server.
* While the server is off, submit the form to add a new entry.
* Open your browser's debugger and navigate to the IndexedDB display (under `Application` in Chrome or `Storage` in Firefox). Click any refresh/reload controls as needed.
* Find the most recent entry in the writes database and expand the `Value`. Under the `request` key, you should see keys `body`, `headers`, `method`, and `url` with appropriate values.