### PR TITLE
Changed column from percent_filled to corals_added

### DIFF
--- a/rails/app/controllers/restoration_activity_log_entries_controller.rb
+++ b/rails/app/controllers/restoration_activity_log_entries_controller.rb
@@ -73,7 +73,7 @@ class RestorationActivityLogEntriesController < ApplicationController
 
   # Never trust parameters from the scary internet, only allow the white list through.
   def restoration_activity_log_entry_params
-    params.require(:restoration_activity_log_entry).permit(:cleaned, :percent_filled, :bleached_corals, :dead_corals, :dive_id, :nursery_table_id, images: [])
+    params.require(:restoration_activity_log_entry).permit(:cleaned, :corals_added, :bleached_corals, :dead_corals, :dive_id, :nursery_table_id, images: [])
   end
 
   def redirect_url(entry)

--- a/rails/app/views/nursery_tables/show.html.erb
+++ b/rails/app/views/nursery_tables/show.html.erb
@@ -24,7 +24,7 @@
       <tr>
         <th scope="col">Date Performed</th>
         <th scope="col">Cleaned?</th>
-        <th scope="col">Percent full</th>
+        <th scope="col">Corals Added</th>
         <th scope="col">Bleached</th>
         <th scope="col">Dead</th>
       </tr>
@@ -38,7 +38,7 @@
               <% else %>
             <td><%= fa_icon "times-circle", class: "text-danger" %></td>
               <% end %>
-            <td><%= entry.percent_filled %>% </td>
+            <td><%= entry.corals_added %>% </td>
             <td><%= entry.bleached_corals %></td>
             <td><%= entry.dead_corals %></td>
         </tr>

--- a/rails/app/views/restoration_activity_log_entries/_form.html.erb
+++ b/rails/app/views/restoration_activity_log_entries/_form.html.erb
@@ -5,7 +5,7 @@
   <div class="form-inputs">
     <%= f.input :nursery_table_id, collection:  @nursery_tables %>
     <%= f.input :cleaned %>
-    <%= f.input :percent_filled %>
+    <%= f.input :corals_added %>
     <%= f.input :bleached_corals %>
     <%= f.input :dead_corals %>
     <%= f.input :dive_id, as: 'hidden' %>

--- a/rails/app/views/restoration_activity_log_entries/_restoration_activity_log_entry.json.jbuilder
+++ b/rails/app/views/restoration_activity_log_entries/_restoration_activity_log_entry.json.jbuilder
@@ -1,7 +1,7 @@
 json.extract! restoration_activity_log_entry,
               :id,
               :cleaned,
-              :percent_filled,
+              :corals_added,
               :bleached_corals,
               :dead_corals,
               :dive_id,

--- a/rails/app/views/restoration_activity_log_entries/index.html.erb
+++ b/rails/app/views/restoration_activity_log_entries/index.html.erb
@@ -8,7 +8,7 @@
           <h5 class="card-title"><%= entry.table_name %></h5>
           <h6 class="card-subtitle mb-2 text-muted"><%= l(entry.created_at) %></h6>
           <p class="card-text">
-            <%= t('.percent_filled_message', percent_filled: entry.percent_filled) %>
+            <%= t('.corals_added_message', corals_added: entry.corals_added) %>
             <%= t('.corals_stats_message', bleached_corals: entry.bleached_corals, dead_corals: entry.dead_corals) %>
           </p>
           <p class="card-text text-muted"><%= t('.cleaned_message', table_cleaned: t(entry.cleaned)) %></p>

--- a/rails/app/views/restoration_activity_log_entries/show.html.erb
+++ b/rails/app/views/restoration_activity_log_entries/show.html.erb
@@ -16,8 +16,8 @@
 </p>
 
 <p>
-  <strong><%= t('restoration_activity_log_entry.attributes.percent_filled') %>:</strong>
-  <%= @restoration_activity_log_entry.percent_filled %>%
+  <strong><%= t('restoration_activity_log_entry.attributes.corals_added') %>:</strong>
+  <%= @restoration_activity_log_entry.corals_added %>%
 </p>
 
 <p>

--- a/rails/config/locales/en.yml
+++ b/rails/config/locales/en.yml
@@ -66,7 +66,7 @@ en:
   restoration_activity_log_entries:
     index:
       title: "Restoration Activity Log Entries"
-      percent_filled_message: "The table is %{percent_filled}% full."
+      corals_added_message: "%{corals_added}% corals were added."
       corals_stats_message: "There are %{bleached_corals} fragmented corals and %{dead_corals} dead corals."
       cleaned_message: "Was the nursery table cleaned? %{table_cleaned}"
       new: "New Restoration Activity Log Entry"

--- a/rails/config/locales/fr.yml
+++ b/rails/config/locales/fr.yml
@@ -66,7 +66,7 @@ fr:
   restoration_activity_log_entries:
     index:
       title: "Entrées du journal des activités de restauration"
-      percent_filled_message: "La table est remplie à %{percent_filled}%."
+      corals_added_message: "%{corals_added}% coraux ont été ajoutés."
       corals_stats_message: "Il y a %{bleached_corals} coraux fragmentés et %{dead_corals} coraux morts."
       cleaned_message: "La table de la pépinière a-t-elle été nettoyée? %{table_cleaned}"
       new: "Nouvelle Entrée du journal des activité de restauration"

--- a/rails/config/locales/models/restoration_activity_log_entries/en.yml
+++ b/rails/config/locales/models/restoration_activity_log_entries/en.yml
@@ -8,7 +8,7 @@ en:
     attributes:
       restoration_activity_log_entry:
         cleaned: 'Cleaned'
-        percent_filled: '% Filled'
+        corals_added: 'Corals Added'
         dive: 'Dive'
         bleached_corals: 'Bleached Corals'
         dead_corals: 'Dead Corals'
@@ -17,7 +17,7 @@ en:
   restoration_activity_log_entry:
     attributes:
       cleaned: 'Cleaned'
-      percent_filled: '% Filled'
+      corals_added: 'Corals Added'
       dive: 'Dive'
       bleached_corals: 'Bleached Corals'
       dead_corals: 'Dead Corals'
@@ -27,7 +27,7 @@ en:
     label:
       restoration_activity_log_entry:
         cleaned: 'Cleaned'
-        percent_filled: '% Filled'
+        corals_added: 'Corals Added'
         dive: 'Dive'
         bleached_corals: 'Bleached Corals'
         dead_corals: 'Dead Corals'

--- a/rails/config/locales/models/restoration_activity_log_entries/fr.yml
+++ b/rails/config/locales/models/restoration_activity_log_entries/fr.yml
@@ -8,7 +8,7 @@ fr:
     attributes:
       restoration_activity_log_entry:
         cleaned: 'Nettoyée'
-        percent_filled: '% rempli'
+        corals_added: 'Coraux Ajoutés'
         dive: 'Plongée'
         bleached_corals: 'Coraux blanchis'
         dead_corals: 'Coraux morts'
@@ -17,7 +17,7 @@ fr:
   restoration_activity_log_entry:
     attributes:
       cleaned: 'Nettoyée'
-      percent_filled: '% rempli'
+      corals_added: 'Coraux Ajoutés'
       dive: 'Plongée'
       bleached_corals: 'Coraux blanchis'
       dead_corals: 'Coraux morts'
@@ -27,7 +27,7 @@ fr:
     label:
       restoration_activity_log_entry:
         cleaned: 'Nettoyée'
-        percent_filled: '% rempli'
+        corals_added: 'Coraux Ajoutés'
         dive: 'Plongée'
         bleached_corals: 'Coraux blanchis'
         dead_corals: 'Coraux morts'

--- a/rails/db/migrate/20191003021702_rename_percent_filled_column.rb
+++ b/rails/db/migrate/20191003021702_rename_percent_filled_column.rb
@@ -1,0 +1,5 @@
+class RenamePercentFilledColumn < ActiveRecord::Migration[5.2]
+  def change
+    rename_column :restoration_activity_log_entries, :percent_filled, :corals_added
+  end
+end

--- a/rails/db/schema.rb
+++ b/rails/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_17_010114) do
+ActiveRecord::Schema.define(version: 2019_10_03_021702) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -55,7 +55,7 @@ ActiveRecord::Schema.define(version: 2019_09_17_010114) do
 
   create_table "restoration_activity_log_entries", force: :cascade do |t|
     t.boolean "cleaned"
-    t.integer "percent_filled"
+    t.integer "corals_added"
     t.integer "bleached_corals"
     t.integer "dead_corals"
     t.integer "dive_id"

--- a/rails/db/seeds.rb
+++ b/rails/db/seeds.rb
@@ -37,7 +37,7 @@ end
 20.times do
   RestorationActivityLogEntry.create(
     cleaned: Faker::Boolean.boolean(0.8),
-    percent_filled: Faker::Number.between(0, 100),
+    corals_added: Faker::Number.between(0, 100),
     bleached_corals: Faker::Number.between(0, 40),
     dead_corals: Faker::Number.between(0, 40),
     dive_id: Faker::Number.between(1, 15),


### PR DESCRIPTION
Resolves some of #80 . Happy to rebase after the related pr is merged too. 

### Description
On our last call with the Coral Gardeners, they clarified that they do not want to log the percent of a table filled when they are on a dive. They merely want to log the number added and removed.
This pr just does the number added because someone else is doing number_removed

### Type of change

* New feature (non-breaking change which adds functionality)
* Breaking change (fix or feature that would cause existing functionality to not 
work as expected) - The i18n will need an update. 