### PR TITLE
border property overide to fix sign-in border not displaying

### DIFF
--- a/rails/app/assets/stylesheets/application.scss
+++ b/rails/app/assets/stylesheets/application.scss
@@ -168,6 +168,9 @@ $highlight-text: #C06D19;
 
   // Buttons //
 
+  .btn {
+    border: 1px solid;
+}
   a.btn {
     background-color: $dark-accent;
     color: $light-shade;


### PR DESCRIPTION
Resolves #73

### Description

I added CSS border property to override `border: 1px solid transparent;` which caused the sign-in border to not be seen.

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Please see screenshots.

### Screenshots

Before:

![Before](https://i.imgur.com/be3pakG.png)

After:

![After](https://i.imgur.com/9Sc3T2w.png)