### PR TITLE
Resolve breaking change in i18n seen here https://github.com/ruby-i18…

### DIFF
--- a/rails/config/environments/production.rb
+++ b/rails/config/environments/production.rb
@@ -68,7 +68,7 @@ Rails.application.configure do
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).
-  config.i18n.fallbacks = true
+  config.i18n.fallbacks = [I18n.default_locale]
 
   # Send deprecation notices to registered listeners.
   config.active_support.deprecation = :notify


### PR DESCRIPTION
…n/i18n/releases/tag/v1.1.0

New i18n version changed the syntax for using fallback locales

When I applies rails 6 and new gems to i18n, I got the following warning. 

```HEADS UP! i18n 1.1 changed fallbacks to exclude default locale.
But that may break your application.

Please check your Rails app for 'config.i18n.fallbacks = true'.
If you're using I18n (>= 1.1.0) and Rails (< 5.2.2), this should be
'config.i18n.fallbacks = [I18n.default_locale]'.
If not, fallbacks will be broken in your app by I18n 1.1.x.

For more info see:
https://github.com/svenfuchs/i18n/releases/tag/v1.1.0 
```
   

### Type of change

<!-- Please delete options that are not relevant. -->

* Configuration change 

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Do we need to do anything else to verify your changes? 
If so, provide instructions (including any relevant configuration) so that 
we can reproduce? -->
Ran the test suite and manually tested the routes. (I clicked on a bunch of stuff.) 

### Screenshots
<!--Optional. Delete if not relevant. 
Include screenshots (before / after) for style changes, highlight 
edited element.-->