### PR TITLE
display a preview of queued writes to the user

### DIFF
--- a/rails/app/views/restoration_activity_log_entries/new.html.erb
+++ b/rails/app/views/restoration_activity_log_entries/new.html.erb
@@ -7,6 +7,25 @@
 
 <%= link_to t('defaults.actions.back'), restoration_activity_log_entries_path %>
 
+<template id="pending-entry-preview-item-template">
+    <li class="list-group-item">
+        <slot name="id">MISSINGID</slot>
+        (<slot name="status">MISSINGSTATUS</slot>)
+
+        <%# should be the same list of visible inputs as in _form.html.erb %>
+        <% [:nursery_table_id,
+            :cleaned,
+            :corals_added,
+            :bleached_corals,
+            :removed_for_planting].each do |input| %>
+        <span>
+            <b><%= t(".restoration_activity_log_entries.form.#{input}") %></b>
+            <slot name="<%= input %>">?</slot>
+        </span>
+        <% end %>
+    </li>
+</template>
+
 <script>
 function initWriteDatabase() {
   return new Promise((resolve, reject) => {
@@ -48,7 +67,6 @@ function previewWrite(write) {
   var headers = (write.request || {})['headers'];
   var content_type = (headers || {})['content-type'];
   var data = {};
-  var values = [];
 
   // parse the POST form body
   if (content_type === 'application/x-www-form-urlencoded') {
@@ -76,15 +94,36 @@ function previewWrite(write) {
     data = write;
   }
 
-  console.log('data', data);
+  var dataSlots = '';
   for (key in data) {
-    values.push('<span><b>' + key + '</b> ' + data[key] + '</span>');
+    if (data[key]) {
+      dataSlots += `<span slot="${key}">${data[key]}</span>`;
+    }
   }
 
-  return(
-    '<li class="list-group-item">' + write.key + ' (' + write.status + ') ' + values.join(', ') + '</li>'
-  );
+  var component = `
+  <pending-entry-preview-item>
+      <span slot="id">${write.key}</span>
+      <span slot="status">${write.status}</span>
+      ${dataSlots}
+  </pending-entry-preview-item>
+  `;
+  return(component);
 }
+
+customElements.define('pending-entry-preview-item',
+  class extends HTMLElement {
+    constructor() {
+      super();
+      var template = document
+        .getElementById('pending-entry-preview-item-template')
+        .content;
+      const shadowRoot = this
+        .attachShadow({mode: 'open'})
+        .appendChild(template.cloneNode(true));
+    }
+  }
+);
 
 document.addEventListener('DOMContentLoaded', () => {
   initWriteDatabase().then(getAllWrites).then(writes => {

--- a/rails/app/views/restoration_activity_log_entries/new.html.erb
+++ b/rails/app/views/restoration_activity_log_entries/new.html.erb
@@ -1,6 +1,7 @@
 <h1><%= t('.title') %></h1>
 
 <p class="alert"><%=t('.pending_entries', count: "-").html_safe %></p>
+<ul id='pending-entry-preview' class="list-group"></ul>
 
 <%= render 'form', restoration_activity_log_entry: @restoration_activity_log_entry %>
 
@@ -42,9 +43,56 @@ function getAllWrites(db) {
   })
 }
 
+function previewWrite(write) {
+  var body = (write.request || {})['body'];
+  var headers = (write.request || {})['headers'];
+  var content_type = (headers || {})['content-type'];
+  var data = {};
+  var values = [];
+
+  // parse the POST form body
+  if (content_type === 'application/x-www-form-urlencoded') {
+    var pairs = body.split('&');
+    for (var i = 0; i < pairs.length; i += 1) {
+      var pair = pairs[i].split('=');
+      var key = decodeURIComponent(pair[0]);
+      var val = decodeURIComponent(pair[1]);
+
+      // remove brackets from param names, e.g., zone[id] => id
+      if (/^[^\[]+\[[^\[\]]+\]$/.test(key)) {
+        key = key.replace(/[^\[]+\[/, '');
+        key = key.replace(/\]/, '');
+      }
+
+      data[key] = val;
+    }
+
+    // omit params that are not part of the form
+    delete data['utf8'];
+    delete data['authenticity_token'];
+    delete data['commit'];
+    delete data['status'];
+  } else {
+    data = write;
+  }
+
+  console.log('data', data);
+  for (key in data) {
+    values.push('<span><b>' + key + '</b> ' + data[key] + '</span>');
+  }
+
+  return(
+    '<li class="list-group-item">' + write.key + ' (' + write.status + ') ' + values.join(', ') + '</li>'
+  );
+}
+
 document.addEventListener('DOMContentLoaded', () => {
   initWriteDatabase().then(getAllWrites).then(writes => {
     document.getElementById('pending-entry-count').innerHTML = writes.length;
+    var preview = document.getElementById('pending-entry-preview');
+    for (var i = 0; i < writes.length; i += 1) {
+      preview.innerHTML += previewWrite(writes[i]);
+    }
   });
 });
 </script>

--- a/rails/config/locales/en.yml
+++ b/rails/config/locales/en.yml
@@ -83,4 +83,9 @@ en:
       at: "at"
     form:
       bleached_corals: 'Bleached Corals'
-
+      cleaned: 'Cleaned'
+      corals_added: 'Corals Added'
+      dead_corals: 'Dead Corals'
+      id: 'ID'
+      nursery_table_id: 'Nursery Table'
+      removed_for_planting: 'Removed for Planting'

--- a/rails/config/locales/fr.yml
+++ b/rails/config/locales/fr.yml
@@ -84,5 +84,10 @@ fr:
       logged_on_dive: "enregistré en plongée"
       at: "à"
     form:
-      total_fragments: "Fragments totaux"
       bleached_corals: 'Coraux blanchis'
+      cleaned: 'Nettoyé'
+      corals_added: 'Coraux ajoutés'
+      dead_corals: 'Coraux morts'
+      id: 'ID'
+      nursery_table_id: 'Table de pépinière'
+      removed_for_planting: 'Enlevé pour la plantation'


### PR DESCRIPTION
### Description

I put this together to improve visibility of the indexeddb data while we are working on it. It might also be helpful to end users to have this feedback, so I added i18n and pushed it for your consideration.

Basically, instead of just showing a count of pending writes, we also show their contents, minus the most arcane things.

### Type of change

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

I tested this by adding data to indexeddb and viewing the offline form. I tested in Firefox on Linux and Safari on iOS. The screenshot below is from iOS.

### Screenshots

![27292203-AA61-4AC5-BD30-0484F99139C7](https://user-images.githubusercontent.com/3877651/67614618-19190e80-f78e-11e9-89f3-150f2b7a6d82.PNG)

